### PR TITLE
Log query params when available

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,22 +2,35 @@
 
 var axios = require('axios')
 var axiosDebug = require('debug')('axios')
+var querystring = require('querystring')
+
+const encodeParams = (params) => params
+  ? '?' + querystring.encode(params)
+  : ''
 
 var options = {
   request: function (debug, config) {
-    debug(config.method.toUpperCase() + ' ' + config.url)
+    const query = encodeParams(config.params)
+
+    debug(
+      config.method.toUpperCase() + ' ' + config.url + query
+    )
   },
   response: function (debug, response) {
+    const query = encodeParams(response.config.params)
+
     debug(
       response.status + ' ' + response.statusText,
-      '(' + response.config.method.toUpperCase() + ' ' + response.config.url + ')'
+      '(' + response.config.method.toUpperCase() + ' ' + response.config.url + query + ')'
     )
   },
   error: function (debug, error) {
     if (error.config) {
+      const query = encodeParams(error.config.params)
+
       debug(
         error.name + ': ' + error.message,
-        '(' + error.config.method.toUpperCase() + ' ' + error.config.url + ')'
+        '(' + error.config.method.toUpperCase() + ' ' + error.config.url + query + ')'
       )
     } else {
       debug(error.name + ': ' + error.message)

--- a/index.js
+++ b/index.js
@@ -1,36 +1,30 @@
 'use strict'
 
 var axios = require('axios')
+var buildURL = require('axios/lib/helpers/buildURL')
 var axiosDebug = require('debug')('axios')
-var querystring = require('querystring')
 
-const encodeParams = (params) => params
-  ? '?' + querystring.encode(params)
-  : ''
+const getURL = (config) => {
+  return buildURL(config.url, config.params, config.paramsSerializer)
+}
 
 var options = {
   request: function (debug, config) {
-    const query = encodeParams(config.params)
-
     debug(
-      config.method.toUpperCase() + ' ' + config.url + query
+      config.method.toUpperCase() + ' ' + getURL(config)
     )
   },
   response: function (debug, response) {
-    const query = encodeParams(response.config.params)
-
     debug(
       response.status + ' ' + response.statusText,
-      '(' + response.config.method.toUpperCase() + ' ' + response.config.url + query + ')'
+      '(' + response.config.method.toUpperCase() + ' ' + getURL(response.config) + ')'
     )
   },
   error: function (debug, error) {
     if (error.config) {
-      const query = encodeParams(error.config.params)
-
       debug(
         error.name + ': ' + error.message,
-        '(' + error.config.method.toUpperCase() + ' ' + error.config.url + query + ')'
+        '(' + error.config.method.toUpperCase() + ' ' + getURL(error.config) + ')'
       )
     } else {
       debug(error.name + ': ' + error.message)

--- a/test.js
+++ b/test.js
@@ -116,6 +116,53 @@ it('should log params of the request of axios instance', () => axios.create()({
   )
 }))
 
+it('should use axios default params when logging the URL', () => axios.create({
+  params: {
+    foo: 'bar'
+  },
+  paramsSerializer: params => {
+    const querystring = require('querystring')
+    return querystring.encode(params) + '&baz=qux'
+  }
+})({
+  method: 'GET',
+  url: 'http://example.com/',
+  adapter: config => Promise.resolve({
+    status: 200,
+    statusText: 'BAR',
+    config
+  })
+}).then(() => {
+  debug.log.should.be.calledTwice()
+  debug.log.firstCall.should.be.calledWithExactly(
+    'GET http://example.com/?foo=bar&baz=qux'
+  )
+  debug.log.secondCall.should.be.calledWithExactly(
+    '200 BAR', '(GET http://example.com/?foo=bar&baz=qux)'
+  )
+}))
+
+it('should log params from both the url and the params of the request', () => axios.create()({
+  method: 'GET',
+  url: 'http://example.com/?foo=bar',
+  params: {
+    name: 'value'
+  },
+  adapter: config => Promise.resolve({
+    status: 200,
+    statusText: 'BAR',
+    config
+  })
+}).then(() => {
+  debug.log.should.be.calledTwice()
+  debug.log.firstCall.should.be.calledWithExactly(
+    'GET http://example.com/?foo=bar&name=value'
+  )
+  debug.log.secondCall.should.be.calledWithExactly(
+    '200 BAR', '(GET http://example.com/?foo=bar&name=value)'
+  )
+}))
+
 it('should log params of the request of axios instance with special characters', () => axios.create()({
   method: 'GET',
   url: 'http://example.com/',
@@ -130,10 +177,10 @@ it('should log params of the request of axios instance with special characters',
 }).then(() => {
   debug.log.should.be.calledTwice()
   debug.log.firstCall.should.be.calledWithExactly(
-    'GET http://example.com/?parameter%20name=%26'
+    'GET http://example.com/?parameter+name=%26'
   )
   debug.log.secondCall.should.be.calledWithExactly(
-    '200 BAR', '(GET http://example.com/?parameter%20name=%26)'
+    '200 BAR', '(GET http://example.com/?parameter+name=%26)'
   )
 }))
 

--- a/test.js
+++ b/test.js
@@ -46,6 +46,23 @@ it('should log request error', () => axios({
   )
 }))
 
+it('should log query params of request in error', () => axios({
+  method: 'FOO',
+  url: 'http://example.com/',
+  params: {
+    name: 'value'
+  },
+  adapter: config => Promise.reject(Object.assign(TypeError('Boom'), { config }))
+}).catch(() => {
+  debug.log.should.be.calledTwice()
+  debug.log.firstCall.should.be.calledWithExactly(
+    'FOO http://example.com/?name=value'
+  )
+  debug.log.secondCall.should.be.calledWithExactly(
+    'TypeError: Boom', '(FOO http://example.com/?name=value)'
+  )
+}))
+
 it('should log general error', () => axios({
   method: 'FOO',
   url: 'http://example.com/',
@@ -75,6 +92,48 @@ it('should logging request of axios instance', () => axios.create()({
   )
   debug.log.secondCall.should.be.calledWithExactly(
     '200 QUX', '(BAZ http://example.com/)'
+  )
+}))
+
+it('should log params of the request of axios instance', () => axios.create()({
+  method: 'GET',
+  url: 'http://example.com/',
+  params: {
+    name: 'value'
+  },
+  adapter: config => Promise.resolve({
+    status: 200,
+    statusText: 'BAR',
+    config
+  })
+}).then(() => {
+  debug.log.should.be.calledTwice()
+  debug.log.firstCall.should.be.calledWithExactly(
+    'GET http://example.com/?name=value'
+  )
+  debug.log.secondCall.should.be.calledWithExactly(
+    '200 BAR', '(GET http://example.com/?name=value)'
+  )
+}))
+
+it('should log params of the request of axios instance with special characters', () => axios.create()({
+  method: 'GET',
+  url: 'http://example.com/',
+  params: {
+    'parameter name': '&'
+  },
+  adapter: config => Promise.resolve({
+    status: 200,
+    statusText: 'BAR',
+    config
+  })
+}).then(() => {
+  debug.log.should.be.calledTwice()
+  debug.log.firstCall.should.be.calledWithExactly(
+    'GET http://example.com/?parameter%20name=%26'
+  )
+  debug.log.secondCall.should.be.calledWithExactly(
+    '200 BAR', '(GET http://example.com/?parameter%20name=%26)'
   )
 }))
 


### PR DESCRIPTION
We are doing many requests on the same URL but with different params.
We'd find it useful to have query params to easily reproduce the URLs we want to debug.

This is what this PR stands for. :slightly_smiling_face: 

Have a nice day!