### PR TITLE
Logging with baseUrl

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,13 @@
 'use strict'
 
+var { URL } = require('url')
 var axios = require('axios')
 var buildURL = require('axios/lib/helpers/buildURL')
 var axiosDebug = require('debug')('axios')
 
 const getURL = (config) => {
-  return buildURL(config.url, config.params, config.paramsSerializer)
+  const fullURL = new URL(config.url, config.baseURL)
+  return buildURL(fullURL.toString(), config.params, config.paramsSerializer)
 }
 
 var options = {

--- a/index.js
+++ b/index.js
@@ -1,12 +1,24 @@
 'use strict'
 
-var { URL } = require('url')
 var axios = require('axios')
+var isAbsoluteURL = require('axios/lib/helpers/isAbsoluteURL')
+var combineURLs = require('axios/lib/helpers/combineURLs')
 var buildURL = require('axios/lib/helpers/buildURL')
 var axiosDebug = require('debug')('axios')
 
+/**
+ * Copy paste from Axios because it appears only in version 0.19.1
+ * @see https://github.com/axios/axios/blob/v0.19.1/lib/core/buildFullPath.js
+ */
+function buildFullPath(baseURL, requestedURL) {
+  if (baseURL && !isAbsoluteURL(requestedURL)) {
+    return combineURLs(baseURL, requestedURL);
+  }
+  return requestedURL;
+}
+
 const getURL = (config) => {
-  const fullURL = new URL(config.url, config.baseURL)
+  const fullURL = buildFullPath(config.baseURL, config.url)
   return buildURL(fullURL.toString(), config.params, config.paramsSerializer)
 }
 

--- a/index.js
+++ b/index.js
@@ -6,15 +6,20 @@ var combineURLs = require('axios/lib/helpers/combineURLs')
 var buildURL = require('axios/lib/helpers/buildURL')
 var axiosDebug = require('debug')('axios')
 
-/**
- * Copy paste from Axios because it appears only in version 0.19.1
- * @see https://github.com/axios/axios/blob/v0.19.1/lib/core/buildFullPath.js
- */
-function buildFullPath(baseURL, requestedURL) {
-  if (baseURL && !isAbsoluteURL(requestedURL)) {
-    return combineURLs(baseURL, requestedURL);
+var buildFullPath;
+try {
+  buildFullPath = require('axios/lib/core/buildFullPath')
+} catch(err) {
+  /**
+   * Copy paste from Axios because it appears only in version 0.19.1
+   * @see https://github.com/axios/axios/blob/v0.19.1/lib/core/buildFullPath.js
+   */
+  buildFullPath = (baseURL, requestedURL) => {
+    if (baseURL && !isAbsoluteURL(requestedURL)) {
+      return combineURLs(baseURL, requestedURL)
+    }
+    return requestedURL
   }
-  return requestedURL;
 }
 
 const getURL = (config) => {

--- a/test.js
+++ b/test.js
@@ -227,6 +227,48 @@ it('should logging request with baseURL', async () => {
   })
 })
 
+it('should logging request with baseURL includes first part of path', async () => {
+  return axios.create()({
+    method: 'BAZ',
+    baseURL: 'http://example.com/foo',
+    url: '/bar',
+    adapter: config => Promise.resolve({
+      status: 200,
+      statusText: 'QUX',
+      config
+    })
+  }).then(() => {
+    debug.log.should.be.calledTwice()
+    debug.log.firstCall.should.be.calledWithExactly(
+      'BAZ http://example.com/foo/bar'
+    )
+    debug.log.secondCall.should.be.calledWithExactly(
+      '200 QUX', '(BAZ http://example.com/foo/bar)'
+    )
+  })
+})
+
+it('should not logging request with baseURL when requested URL absolute', async () => {
+  return axios.create()({
+    method: 'BAZ',
+    baseURL: 'http://first.com/foo',
+    url: 'http://second.com/bar',
+    adapter: config => Promise.resolve({
+      status: 200,
+      statusText: 'QUX',
+      config
+    })
+  }).then(() => {
+    debug.log.should.be.calledTwice()
+    debug.log.firstCall.should.be.calledWithExactly(
+      'BAZ http://second.com/bar'
+    )
+    debug.log.secondCall.should.be.calledWithExactly(
+      '200 QUX', '(BAZ http://second.com/bar)'
+    )
+  })
+})
+
 it('should be able to set format of response & response logging', () => {
   const requestLogger = sinon.spy((debug, config) => debug(config.method.toUpperCase()))
   const responseLogger = sinon.spy((debug, response) => debug(response.statusText.toUpperCase()))

--- a/test.js
+++ b/test.js
@@ -206,6 +206,27 @@ it('should add custom debug logger to axios instance', () => {
   })
 })
 
+it('should logging request with baseURL', async () => {
+  return axios.create()({
+    method: 'BAZ',
+    baseURL: 'http://example.com/',
+    url: '/path',
+    adapter: config => Promise.resolve({
+      status: 200,
+      statusText: 'QUX',
+      config
+    })
+  }).then(() => {
+    debug.log.should.be.calledTwice()
+    debug.log.firstCall.should.be.calledWithExactly(
+      'BAZ http://example.com/path'
+    )
+    debug.log.secondCall.should.be.calledWithExactly(
+      '200 QUX', '(BAZ http://example.com/path)'
+    )
+  })
+})
+
 it('should be able to set format of response & response logging', () => {
   const requestLogger = sinon.spy((debug, config) => debug(config.method.toUpperCase()))
   const responseLogger = sinon.spy((debug, response) => debug(response.statusText.toUpperCase()))


### PR DESCRIPTION
Hello, I noticed that the URL is logging not completely when using `baseUrl` config property.

For example:
```js
axios.create({
    baseURL: 'https://example.com/path',
}).get('/to');
```

Before:
```
axios 200 OK (GET /to) +325ms
```

After:
```
axios 200 OK (GET https://example.com/path/to) +325ms
```