### PR TITLE
refactor: :label: make `debug` param of `addLogger` optional

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -8,7 +8,7 @@ declare interface UserOptions {
 }
 
 declare const config: ((userOptions: UserOptions) => void) & {
-  addLogger(instance: AxiosInstance, debug: Debugger): void;
+  addLogger(instance: AxiosInstance, debug?: Debugger): void;
 }
 
 export = config;


### PR DESCRIPTION
[`addLogger` already handles the case where the `debug` param is undefined](https://github.com/Gerhut/axios-debug-log/blob/45196b201aae42f2482a716388300f1be3335523/index.js#L48), so we need to allow TypeScript users to skip this parameter