### PR TITLE
fix(types): mark all options as non-required

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,9 +2,9 @@ import { AxiosInstance, AxiosRequestConfig, AxiosResponse, AxiosError } from "ax
 import { Debugger } from "debug";
 
 declare interface UserOptions {
-  request?: (debug: Debugger, config: AxiosRequestConfig) => void;
-  response?: (debug: Debugger, response: AxiosResponse) => void;
-  error?: (debug: Debugger, error: AxiosError) => void;
+  request?(debug: Debugger, config: AxiosRequestConfig): void;
+  response?(debug: Debugger, response: AxiosResponse): void;
+  error?(debug: Debugger, error: AxiosError): void;
 }
 
 declare const config: ((userOptions: UserOptions) => void) & {

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,9 +2,9 @@ import { AxiosInstance, AxiosRequestConfig, AxiosResponse, AxiosError } from "ax
 import { Debugger } from "debug";
 
 declare interface UserOptions {
-  request(debug: Debugger, config: AxiosRequestConfig): void;
-  response(debug: Debugger, response: AxiosResponse): void;
-  error(debug: Debugger, error: AxiosError): void;
+  request?: (debug: Debugger, config: AxiosRequestConfig) => void;
+  response?: (debug: Debugger, response: AxiosResponse) => void;
+  error?: (debug: Debugger, error: AxiosError) => void;
 }
 
 declare const config: ((userOptions: UserOptions) => void) & {


### PR DESCRIPTION
Currently all options are marked required in type definitions, which is not how the module actually works (user may never pass `error` callback, for example).